### PR TITLE
MODEXPS-94 Export eHoldings: Add eholdings export type

### DIFF
--- a/schemas/eholdings/eHoldingsExportConfig.json
+++ b/schemas/eholdings/eHoldingsExportConfig.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "The schema describes an export parameters for the eHoldings application",
+  "EHoldingsExportConfig": {
+    "type": "object",
+    "properties": {
+      "packageSearchQuery": {
+        "description": "The cql query needed to search the exporting package",
+        "type": "string"
+      },
+      "titleSearchQuery": {
+        "description": "The cql query needed to search an attached titles to the package",
+        "type": "string"
+      },
+      "packageFields": {
+        "description": "The list of package fields for export",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "titleFields": {
+        "description": "The list of title fields for export",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/schemas/exportType.json
+++ b/schemas/exportType.json
@@ -13,7 +13,7 @@
       "BULK_EDIT_IDENTIFIERS",
       "BULK_EDIT_QUERY",
       "BULK_EDIT_UPDATE",
-      "EHOLDINGS"
+      "E_HOLDINGS"
     ],
     "default": "BURSAR_FEES_FINES"
   }

--- a/schemas/exportType.json
+++ b/schemas/exportType.json
@@ -12,7 +12,8 @@
       "INVOICE_EXPORT",
       "BULK_EDIT_IDENTIFIERS",
       "BULK_EDIT_QUERY",
-      "BULK_EDIT_UPDATE"
+      "BULK_EDIT_UPDATE",
+      "EHOLDINGS"
     ],
     "default": "BURSAR_FEES_FINES"
   }

--- a/schemas/exportTypeSpecificParameters.json
+++ b/schemas/exportTypeSpecificParameters.json
@@ -14,6 +14,9 @@
         "description": "CQL query to be passed to the module which data is being exported. Use it to filter data.",
         "type": "string",
         "maxLength": 5000
+      },
+      "eHoldingsExportConfig": {
+        "$ref": "eholdings/eHoldingsExportConfig.json#/EHoldingsExportConfig"
       }
     }
   }


### PR DESCRIPTION
## Approach
- add new export type - 'eHoldings', this allows the UI application to show and filter new eHoldings jobs;
- add new request parameters (to ExportTypeSpecificParameters.json) needed to pass export fields, search params for titles search, and other params; see  [exportTypeSpecificParameters.json](https://issues.folio.org/secure/attachment/47086/47086_exportTypeSpecificParameters.json)  [eHoldingsExportConfig.json](https://issues.folio.org/secure/attachment/47090/47090_eHoldingsExportConfig.json)

## Learning
https://issues.folio.org/browse/MODEXPS-94