### PR TITLE
FEXPCMN-13 - Improve UserConteUpdate schema

### DIFF
--- a/schemas/bulk-edit/userContentUpdate.json
+++ b/schemas/bulk-edit/userContentUpdate.json
@@ -16,28 +16,7 @@
       "actions": {
         "type": "array",
         "items": {
-          "description": "Changing action",
-          "type": "object",
-          "properties": {
-            "name": {
-              "description": "Action name",
-              "type": "string",
-              "enum": [
-                "FIND",
-                "ADD_TO_EXISTING",
-                "CLEAR_FIELD",
-                "REPLACE_WITH",
-                "FIND_AND_REMOVE_THESE"
-              ]
-            },
-            "value": {
-              "description": "Action value",
-              "type": "object"
-            }
-          },
-          "required": [
-            "name"
-          ]
+          "$ref": "userContentUpdateAction.json#/UserContentUpdateAction"
         },
         "minItems": 1
       }

--- a/schemas/bulk-edit/userContentUpdateAction.json
+++ b/schemas/bulk-edit/userContentUpdateAction.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "User content update",
+  "UserContentUpdateAction": {
+    "description": "User Changing action",
+    "type": "object",
+    "properties": {
+      "name": {
+        "description": "Action name",
+        "type": "string",
+        "enum": [
+          "FIND",
+          "ADD_TO_EXISTING",
+          "CLEAR_FIELD",
+          "REPLACE_WITH",
+          "FIND_AND_REMOVE_THESE"
+        ]
+      },
+      "value": {
+        "description": "Action value",
+        "type": "object"
+      }
+    },
+    "required": [
+      "name"
+    ],
+    "additionalProperties": false
+  }
+}


### PR DESCRIPTION
[FEXPCMN-13](https://issues.folio.org/browse/FEXPCMN-13) - Improve UserConteUpdate schema

## Purpose
In order to generate models properly, user content update action should be extracted into separate json schema.

## Approach
* created userContentUpdateAction.json schema


## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
