### PR TITLE
UXPROD-3903: New schemas to support new bursar export configuration feature

### DIFF
--- a/schemas/bursar-export/bursarExportJob.json
+++ b/schemas/bursar-export/bursarExportJob.json
@@ -1,0 +1,52 @@
+{
+  "description": "Bursar export job schema",
+  "type": "object",
+  "properties": {
+    "filter": {
+      "description": "Filter to use for the regular export",
+      "$ref": "filter/bursarExportFilter.json"
+    },
+    "groupByPatron": {
+      "description": "Choose whether to group fee/fines by patron",
+      "type": "boolean"
+    },
+    "groupByPatronFilter": {
+      "description": "Filter to use for the export when grouping by patron",
+      "$ref": "filter/bursarExportFilterAggregate.json"
+    },
+    "header": {
+      "description": "Header format for the export file",
+      "type": "array",
+      "items": {
+        "$ref": "tokens/bursarExportHeaderFooter.json"
+      }
+    },
+    "data": {
+      "description": "Data format for the export file",
+      "type": "array",
+      "items": {
+        "$ref": "tokens/bursarExportDataToken.json"
+      }
+    },
+    "footer": {
+      "description": "Footer format for the export file",
+      "type": "array",
+      "items": {
+        "$ref": "tokens/bursarExportHeaderFooter.json"
+      }
+    },
+    "transferInfo": {
+      "description": "Transfer information for the export",
+      "$ref": "transfer/bursarExportTransferCriteria.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "filter",
+    "groupByPatron",
+    "header",
+    "data",
+    "footer",
+    "transferInfo"
+  ]
+}

--- a/schemas/bursar-export/filter/bursarExportFilter.json
+++ b/schemas/bursar-export/filter/bursarExportFilter.json
@@ -1,0 +1,50 @@
+{
+  "description": "Filter for bursar export job",
+  "oneOf": [
+    {
+      "$ref": "bursarExportFilterAge.json"
+    },
+    {
+      "$ref": "bursarExportFilterAmount.json"
+    },
+    {
+      "$ref": "bursarExportFilterFeeType.json"
+    },
+    {
+      "$ref": "bursarExportFilterLocation.json"
+    },
+    {
+      "$ref": "bursarExportFilterPatronGroup.json"
+    },
+    {
+      "$ref": "bursarExportFilterServicePoint.json"
+    },
+    {
+      "$ref": "bursarExportFilterCondition.json"
+    },
+    {
+      "$ref": "bursarExportFilterNegation.json"
+    },
+    {
+      "$ref": "bursarExportFilterPass.json"
+    },
+    {
+      "$ref": "bursarExportFilterFeeFineOwner.json"
+    }
+  ],
+  "discriminator": {
+    "propertyName": "type",
+    "mapping": {
+      "Age": "bursarExportFilterAge.json",
+      "Amount": "bursarExportFilterAmount.json",
+      "FeeType": "bursarExportFilterFeeType.json",
+      "FeeFineOwner": "bursarExportFilterFeeFineOwner.json",
+      "Location": "bursarExportFilterLocation.json",
+      "PatronGroup": "bursarExportFilterPatronGroup.json",
+      "ServicePoint": "bursarExportFilterServicePoint.json",
+      "Condition": "bursarExportFilterCondition.json",
+      "Negation": "bursarExportFilterNegation.json",
+      "Pass": "bursarExportFilterPass.json"
+    }
+  }
+}

--- a/schemas/bursar-export/filter/bursarExportFilterAge.json
+++ b/schemas/bursar-export/filter/bursarExportFilterAge.json
@@ -1,0 +1,29 @@
+{
+  "description": "Filter by fees within certain days range",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of filter",
+      "type": "string",
+      "default": "Age"
+    },
+    "numDays": {
+      "description": "Number of days",
+      "type": "integer",
+      "minimum": 1
+    },
+    "condition": {
+      "description": "Condition to get days range",
+      "type": "string",
+      "enum": [
+        "LESS_THAN_EQUAL",
+        "LESS_THAN",
+        "GREATER_THAN",
+        "GREATER_THAN_EQUAL"
+      ]
+    }
+
+  },
+  "additionalProperties": false,
+  "required": ["type", "numDays", "condition"]
+}

--- a/schemas/bursar-export/filter/bursarExportFilterAggregate.json
+++ b/schemas/bursar-export/filter/bursarExportFilterAggregate.json
@@ -1,0 +1,32 @@
+{
+  "description": "Filter by aggregate data",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of filter",
+      "type": "string",
+      "default": "Aggregate"
+    },
+    "property": {
+      "description": "Property to filter on",
+      "type": "string",
+      "enum": ["NUM_ROWS", "TOTAL_AMOUNT"]
+    },
+    "amount": {
+      "description": "Amount to filter on",
+      "type": "integer"
+    },
+    "condition": {
+      "description": "Condition to filter on",
+      "type": "string",
+      "enum": [
+        "LESS_THAN_EQUAL",
+        "LESS_THAN",
+        "GREATER_THAN",
+        "GREATER_THAN_EQUAL"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type", "property", "amount", "condition"]
+}

--- a/schemas/bursar-export/filter/bursarExportFilterAmount.json
+++ b/schemas/bursar-export/filter/bursarExportFilterAmount.json
@@ -1,0 +1,27 @@
+{
+  "description": "Filter by fee amount",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of filter",
+      "type": "string",
+      "default": "Amount"
+    },
+    "amount": {
+      "description": "Amount to filter by",
+      "type": "integer"
+    },
+    "condition": {
+      "description": "Condition to filter by",
+      "type": "string",
+      "enum": [
+        "LESS_THAN_EQUAL",
+        "LESS_THAN",
+        "GREATER_THAN",
+        "GREATER_THAN_EQUAL"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type", "amount", "condition"]
+}

--- a/schemas/bursar-export/filter/bursarExportFilterCondition.json
+++ b/schemas/bursar-export/filter/bursarExportFilterCondition.json
@@ -1,0 +1,25 @@
+{
+  "description": "Filter conditional operations",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of filter",
+      "type": "string",
+      "default": "Condition"
+    },
+    "operation": {
+      "description": "Conditional operation of the filter",
+      "type": "string",
+      "enum": ["AND", "OR"]
+    },
+    "criteria": {
+      "description": "Criteria to apply of the filter",
+      "type": "array",
+      "items": {
+        "$ref": "bursarExportFilter.json"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type", "operation", "criteria"]
+}

--- a/schemas/bursar-export/filter/bursarExportFilterFeeFineOwner.json
+++ b/schemas/bursar-export/filter/bursarExportFilterFeeFineOwner.json
@@ -1,0 +1,18 @@
+{
+  "description": "Filter by fee fine owner",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of filter",
+      "type": "string",
+      "default": "FeeFineOwner"
+    },
+    "feeFineOwner": {
+      "description": "Id of fee/fine owner to filter by",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type", "feeFineOwner"]
+}

--- a/schemas/bursar-export/filter/bursarExportFilterFeeType.json
+++ b/schemas/bursar-export/filter/bursarExportFilterFeeType.json
@@ -1,0 +1,18 @@
+{
+  "description": "Filter by fee type",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of filter",
+      "type": "string",
+      "default": "FeeType"
+    },
+    "feeFineTypeId": {
+      "description": "Id of fee/fine type to filter by",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type", "feeFineTypeId"]
+}

--- a/schemas/bursar-export/filter/bursarExportFilterLocation.json
+++ b/schemas/bursar-export/filter/bursarExportFilterLocation.json
@@ -1,0 +1,18 @@
+{
+  "description": "Filter by location",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of filter",
+      "type": "string",
+      "default": "Location"
+    },
+    "locationId": {
+      "description": "Id of location to filter by",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type", "locationId"]
+}

--- a/schemas/bursar-export/filter/bursarExportFilterNegation.json
+++ b/schemas/bursar-export/filter/bursarExportFilterNegation.json
@@ -1,0 +1,17 @@
+{
+  "description": "Negation of filter for bursar export",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of filter",
+      "type": "string",
+      "default": "Negation"
+    },
+    "criteria": {
+      "description": "Filter to negate",
+      "$ref": "bursarExportFilter.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type", "criteria"]
+}

--- a/schemas/bursar-export/filter/bursarExportFilterPass.json
+++ b/schemas/bursar-export/filter/bursarExportFilterPass.json
@@ -1,0 +1,13 @@
+{
+  "description": "Filter that is always true",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of filter",
+      "type": "string",
+      "default": "Pass"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type"]
+}

--- a/schemas/bursar-export/filter/bursarExportFilterPatronGroup.json
+++ b/schemas/bursar-export/filter/bursarExportFilterPatronGroup.json
@@ -1,0 +1,18 @@
+{
+  "description": "Filter by patron group",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of filter",
+      "type": "string",
+      "default": "PatronGroup"
+    },
+    "patronGroupId": {
+      "description": "Id of patron group to filter by",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type", "patronGroupId"]
+}

--- a/schemas/bursar-export/filter/bursarExportFilterServicePoint.json
+++ b/schemas/bursar-export/filter/bursarExportFilterServicePoint.json
@@ -1,0 +1,18 @@
+{
+  "description": "Filter by service point",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of filter",
+      "type": "string",
+      "default": "ServicePoint"
+    },
+    "servicePointId": {
+      "description": "Id of service point to filter by",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type", "servicePointId"]
+}

--- a/schemas/bursar-export/legacy/legacyBursarFeeFines.json
+++ b/schemas/bursar-export/legacy/legacyBursarFeeFines.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "Fees and fines for bursar export parameters",
-  "BursarFeeFines": {
+  "description": "Migration - Fees and fines for bursar export parameters",
+  "LegacyBursarFeeFines": {
     "type": "object",
     "properties": {
       "daysOutstanding": {
@@ -39,7 +39,7 @@
         "additionalProperties" : {
           "type": "array",
           "items": {
-            "$ref": "bursarFeeFinesTypeMapping.json#/BursarFeeFinesTypeMapping"
+            "$ref": "legacyBursarFeeFinesTypeMapping.json#/LegacyBursarFeeFinesTypeMapping"
           }
         }
       }

--- a/schemas/bursar-export/legacy/legacyBursarFeeFinesTypeMapping.json
+++ b/schemas/bursar-export/legacy/legacyBursarFeeFinesTypeMapping.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "Fees and fines for bursar type mapping",
-  "BursarFeeFinesTypeMapping": {
+  "description": "Migration - Fees and fines for bursar type mapping",
+  "LegacyBursarFeeFinesTypeMapping": {
     "type": "object",
     "properties": {
       "feefineTypeId": {
@@ -11,7 +11,7 @@
       "itemType": {
         "type": "string",
         "minLength": 1,
-        "maxLength": 12
+        "maxLength": 1
       },
       "itemDescription": {
         "type": "string",

--- a/schemas/bursar-export/legacy/legacyExportTypeSpecificParameters.json
+++ b/schemas/bursar-export/legacy/legacyExportTypeSpecificParameters.json
@@ -1,14 +1,14 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "Export parameters which depend on export type",
-  "ExportTypeSpecificParameters": {
+  "description": "Migration - Export parameters which depend on export type",
+  "LegacyExportTypeSpecificParameters": {
     "type": "object",
     "properties": {
       "bursarFeeFines": {
-        "$ref": "bursar-export/bursarExportJob.json"
+        "$ref": "legacyBursarFeeFines.json#/LegacyBursarFeeFines"
       },
       "vendorEdiOrdersExportConfig": {
-        "$ref": "acquisitions/vendorEdiOrdersExportConfig.json#/VendorEdiOrdersExportConfig"
+        "$ref": "../../acquisitions/vendorEdiOrdersExportConfig.json#/VendorEdiOrdersExportConfig"
       },
       "query": {
         "description": "CQL query to be passed to the module which data is being exported. Use it to filter data.",
@@ -16,10 +16,10 @@
         "maxLength": 5000
       },
       "eHoldingsExportConfig": {
-        "$ref": "eholdings/eHoldingsExportConfig.json#/EHoldingsExportConfig"
+        "$ref": "../../eholdings/eHoldingsExportConfig.json#/EHoldingsExportConfig"
       },
       "authorityControlExportConfig": {
-        "$ref": "authority-control/authorityControlExportConfig.json#/AuthorityControlExportConfig"
+        "$ref": "../../authority-control/authorityControlExportConfig.json#/AuthorityControlExportConfig"
       }
     }
   }

--- a/schemas/bursar-export/legacy/legacyJob.json
+++ b/schemas/bursar-export/legacy/legacyJob.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "older schema for Job",
+  "LegacyJob": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "description": "Job ID",
+        "type": "string",
+        "format": "uuid"
+      },
+      "name": {
+        "description": "Job name",
+        "type": "string",
+        "maxLength": 100
+      },
+      "description": {
+        "description": "Job description",
+        "type": "string"
+      },
+      "source": {
+        "description": "Job source",
+        "type": "string",
+        "maxLength": 50
+      },
+      "isSystemSource": {
+        "description": "Was the job created by system",
+        "type": "boolean"
+      },
+      "tenant": {
+        "description": "Tenant id",
+        "type": "string"
+      },
+      "type": {
+        "description": "Export type",
+        "$ref": "../../exportType.json#/ExportType"
+      },
+      "exportTypeSpecificParameters": {
+        "$ref": "legacyExportTypeSpecificParameters.json#/LegacyExportTypeSpecificParameters"
+      },
+      "status": {
+        "description": "Job status",
+        "$ref": "../../jobStatus.json#/JobStatus"
+      },
+      "files": {
+        "description": "Export files URLs",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "fileNames": {
+        "description": "Exported files",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "startTime": {
+        "description": "Job start timestamp",
+        "type": "string",
+        "format": "date-time"
+      },
+      "endTime": {
+        "description": "Job end timestamp",
+        "type": "string",
+        "format": "date-time"
+      },
+      "metadata": {
+        "description": "Standard FOLIO metadata",
+        "$ref": "../../common/metadata.json#/Metadata"
+      },
+      "outputFormat": {
+        "description": "Job output format",
+        "type": "string",
+        "maxLength": 50
+      },
+      "errorDetails": {
+        "description": "Job error details",
+        "type": "string"
+      },
+      "identifierType": {
+        "description": "Identifier type",
+        "$ref": "../../bulk-edit/identifierType.json#/IdentifierType"
+      },
+      "entityType": {
+        "description": "Entity type",
+        "$ref": "../../bulk-edit/entityType.json#/EntityType"
+      },
+      "progress": {
+        "description": "Progress for records being processed",
+        "$ref": "../../progress.json#/Progress"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "type",
+      "exportTypeSpecificParameters"
+    ]
+  }
+}

--- a/schemas/bursar-export/legacy/legacyJobCollection.json
+++ b/schemas/bursar-export/legacy/legacyJobCollection.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Migration - Collection of jobs",
+  "LegacyJobCollection": {
+    "type": "object",
+    "properties": {
+      "jobRecords": {
+        "type": "array",
+        "description": "Jobs",
+        "items": {
+          "$ref": "legacyJob.json#/LegacyJob"
+        }
+      },
+      "totalRecords": {
+        "type": "integer"
+      }
+    },
+    "required": [
+      "jobRecords",
+      "totalRecords"
+    ]
+  }
+}

--- a/schemas/bursar-export/tokens/bursarExportDataToken.json
+++ b/schemas/bursar-export/tokens/bursarExportDataToken.json
@@ -1,0 +1,50 @@
+{
+  "description": "Usable token for bursar export",
+  "oneOf": [
+    {
+      "$ref": "bursarExportTokenAggregate.json"
+    },
+    {
+      "$ref": "bursarExportTokenConstant.json"
+    },
+    {
+      "$ref": "bursarExportTokenCurrentDate.json"
+    },
+    {
+      "$ref": "bursarExportTokenFeeDate.json"
+    },
+    {
+      "$ref": "bursarExportTokenFeeAmount.json"
+    },
+    {
+      "$ref": "bursarExportTokenFeeMetadata.json"
+    },
+    {
+      "$ref": "bursarExportTokenItemData.json"
+    },
+    {
+      "$ref": "bursarExportTokenUserData.json"
+    },
+    {
+      "$ref": "bursarExportTokenUserDataOptional.json"
+    },
+    {
+      "$ref": "bursarExportTokenConditional.json"
+    }
+  ],
+  "discriminator": {
+    "propertyName": "type",
+    "mapping": {
+      "Aggregate": "bursarExportTokenAggregate.json",
+      "Constant": "bursarExportTokenConstant.json",
+      "CurrentDate": "bursarExportTokenCurrentDate.json",
+      "FeeDate": "bursarExportTokenFeeDate.json",
+      "FeeAmount": "bursarExportTokenFeeAmount.json",
+      "FeeMetadata": "bursarExportTokenFeeMetadata.json",
+      "ItemData": "bursarExportTokenItemData.json",
+      "UserData": "bursarExportTokenUserData.json",
+      "UserDataOptional": "bursarExportTokenUserDataOptional.json",
+      "Conditional": "bursarExportTokenConditional.json"
+    }
+  }
+}

--- a/schemas/bursar-export/tokens/bursarExportHeaderFooter.json
+++ b/schemas/bursar-export/tokens/bursarExportHeaderFooter.json
@@ -1,0 +1,16 @@
+{
+  "description": "Token permitted in header/footer",
+  "oneOf": [
+    { "$ref": "bursarExportTokenAggregate.json" },
+    { "$ref": "bursarExportTokenConstant.json" },
+    { "$ref": "bursarExportTokenCurrentDate.json" }
+  ],
+  "discriminator": {
+    "propertyName": "type",
+    "mapping": {
+      "Aggregate": "bursarExportTokenAggregate.json",
+      "Constant": "bursarExportTokenConstant.json",
+      "CurrentDate": "bursarExportTokenCurrentDate.json"
+    }
+  }
+}

--- a/schemas/bursar-export/tokens/bursarExportTokenAggregate.json
+++ b/schemas/bursar-export/tokens/bursarExportTokenAggregate.json
@@ -1,0 +1,26 @@
+{
+  "description": "Token to represent aggregated result of multiple fees",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of data token",
+      "type": "string",
+      "default": "Aggregate"
+    },
+    "value": {
+      "description": "Data to represent",
+      "type": "string",
+      "enum": ["NUM_ROWS", "TOTAL_AMOUNT"]
+    },
+    "decimal": {
+      "type": "boolean",
+      "description": "Whether to return value with decimal. Only applicable for total amount"
+    },
+    "lengthControl": {
+      "description": "Control length of the token",
+      "$ref": "bursarExportTokenLengthControl.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type", "value", "decimal"]
+}

--- a/schemas/bursar-export/tokens/bursarExportTokenConditional.json
+++ b/schemas/bursar-export/tokens/bursarExportTokenConditional.json
@@ -1,0 +1,36 @@
+{
+  "description": "Token to represent other data tokens depending on certain conditions",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of the data token",
+      "type": "string",
+      "default": "Conditional"
+    },
+    "conditions": {
+      "description": "Conditions to apply to the token",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "condition": {
+            "description": "Condition to apply to the item",
+            "$ref": "../filter/bursarExportFilter.json"
+          },
+          "value": {
+            "description": "Data to represent if the condition is true",
+            "$ref": "bursarExportDataToken.json"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["condition", "value"]
+      }
+    },
+    "else": {
+      "description": "Data to represent if no condition is true",
+      "$ref": "bursarExportDataToken.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type", "conditions", "else"]
+}

--- a/schemas/bursar-export/tokens/bursarExportTokenConstant.json
+++ b/schemas/bursar-export/tokens/bursarExportTokenConstant.json
@@ -1,0 +1,17 @@
+{
+  "description": "Token to represent a constant used as an arbitrary string",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of data token",
+      "type": "string",
+      "default": "Constant"
+    },
+    "value": {
+      "description": "Value of the constant",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type", "value"]
+}

--- a/schemas/bursar-export/tokens/bursarExportTokenCurrentDate.json
+++ b/schemas/bursar-export/tokens/bursarExportTokenCurrentDate.json
@@ -1,0 +1,25 @@
+{
+  "description": "Token to represent part of date",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of data token",
+      "type": "string",
+      "default": "Date"
+    },
+    "value": {
+      "description": "Type of date value to represent",
+      "$ref": "bursarExportTokenDateType.json"
+    },
+    "timezone": {
+      "description": "Timezone to use for date",
+      "type": "string"
+    },
+    "lengthControl": {
+      "description": "Control length of the token",
+      "$ref": "bursarExportTokenLengthControl.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type", "value", "timezone"]
+}

--- a/schemas/bursar-export/tokens/bursarExportTokenDateType.json
+++ b/schemas/bursar-export/tokens/bursarExportTokenDateType.json
@@ -1,0 +1,21 @@
+{
+  "description": "Schema to represent the type of date information",
+  "type": "string",
+  "enum": [
+    "YEAR_LONG",
+    "YEAR_SHORT",
+    "MONTH",
+    "DATE",
+    "HOUR",
+    "MINUTE",
+    "SECOND",
+    "QUARTER",
+    "WEEK_OF_YEAR_ISO",
+    "WEEK_YEAR_ISO",
+    "DAY_OF_YEAR",
+    "YYYYMMDD",
+    "YYYY-MM-DD",
+    "MMDDYYYY",
+    "DDMMYYYY"
+  ]
+}

--- a/schemas/bursar-export/tokens/bursarExportTokenFeeAmount.json
+++ b/schemas/bursar-export/tokens/bursarExportTokenFeeAmount.json
@@ -1,0 +1,21 @@
+{
+  "description": "Token to represent fee amount",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of data token",
+      "type": "string",
+      "default": "FeeAmount"
+    },
+    "decimal": {
+      "description": "Whether to return value with decimal",
+      "type": "boolean"
+    },
+    "lengthControl": {
+      "description": "Control length of the token",
+      "$ref": "bursarExportTokenLengthControl.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type", "decimal"]
+}

--- a/schemas/bursar-export/tokens/bursarExportTokenFeeDate.json
+++ b/schemas/bursar-export/tokens/bursarExportTokenFeeDate.json
@@ -1,0 +1,34 @@
+{
+  "description": "Token to represent part of date about a fee",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of data token",
+      "type": "string",
+      "default": "FeeDate"
+    },
+    "property": {
+      "description": "Property of fee to be represented by token",
+      "type": "string",
+      "enum": ["CREATED", "UPDATED", "DUE", "RETURNED"]
+    },
+    "value": {
+      "description": "Type of date value to represent",
+      "$ref": "bursarExportTokenDateType.json"
+    },
+    "placeholder": {
+      "description": "Placeholder value to use if date is not available",
+      "type": "string"
+    },
+    "timezone": {
+      "description": "Timezone to use for date",
+      "type": "string"
+    },
+    "lengthControl": {
+      "description": "Control length of token",
+      "$ref": "bursarExportTokenLengthControl.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type", "property", "value", "placeholder", "timezone"]
+}

--- a/schemas/bursar-export/tokens/bursarExportTokenFeeMetadata.json
+++ b/schemas/bursar-export/tokens/bursarExportTokenFeeMetadata.json
@@ -1,0 +1,22 @@
+{
+  "description": "Token to represent fee metadata",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of data token",
+      "type": "string",
+      "default": "FeeMetadata"
+    },
+    "value": {
+      "description": "Metadata to represent",
+      "type": "string",
+      "enum": ["FEE_FINE_TYPE_ID", "FEE_FINE_TYPE_NAME"]
+    },
+    "lengthControl": {
+      "description": "Control length of token",
+      "$ref": "bursarExportTokenLengthControl.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type", "value"]
+}

--- a/schemas/bursar-export/tokens/bursarExportTokenItemData.json
+++ b/schemas/bursar-export/tokens/bursarExportTokenItemData.json
@@ -1,0 +1,34 @@
+{
+  "description": "Token to represent item data",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of token",
+      "type": "string",
+      "default": "ItemData"
+    },
+    "value": {
+      "description": "Item data to represent",
+      "type": "string",
+      "enum": [
+        "BARCODE",
+        "NAME",
+        "MATERIAL_TYPE",
+        "INSTITUTION_ID",
+        "CAMPUS_ID",
+        "LIBRARY_ID",
+        "LOCATION_ID"
+      ]
+    },
+    "placeholder": {
+      "description": "Placeholder text to display when no value is available",
+      "type": "string"
+    },
+    "lengthControl": {
+      "description": "Control length of token",
+      "$ref": "bursarExportTokenLengthControl.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type", "value", "placeholder"]
+}

--- a/schemas/bursar-export/tokens/bursarExportTokenLengthControl.json
+++ b/schemas/bursar-export/tokens/bursarExportTokenLengthControl.json
@@ -1,0 +1,34 @@
+{
+  "description": "Token to fill in or truncate the length of another token",
+  "type": "object",
+  "properties": {
+    "character": {
+      "description": "Character to fill in with",
+      "type": "string",
+      "maxLength": 1
+    },
+    "length": {
+      "description": "Desired length for the token",
+      "type": "integer"
+    },
+    "direction": {
+      "description": "Direction to fill in or truncate from",
+      "type": "string",
+      "enum": [
+        "FRONT",
+        "BACK"
+      ]
+    },
+    "truncate": {
+      "description": "Whether to truncate the token if it is longer than the desired length",
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "character",
+    "length",
+    "direction",
+    "truncate"
+  ]
+}

--- a/schemas/bursar-export/tokens/bursarExportTokenUserData.json
+++ b/schemas/bursar-export/tokens/bursarExportTokenUserData.json
@@ -1,0 +1,22 @@
+{
+  "description": "Token to represent user data",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of data token",
+      "type": "string",
+      "default": "UserData"
+    },
+    "value": {
+      "description": "User data to represent",
+      "type": "string",
+      "enum": ["FOLIO_ID"]
+    },
+    "lengthControl": {
+      "description": "Control length of token",
+      "$ref": "bursarExportTokenLengthControl.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type", "value"]
+}

--- a/schemas/bursar-export/tokens/bursarExportTokenUserDataOptional.json
+++ b/schemas/bursar-export/tokens/bursarExportTokenUserDataOptional.json
@@ -1,0 +1,26 @@
+{
+  "description": "Token to represent optional user data",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of data token",
+      "type": "string",
+      "default": "UserDataOptional"
+    },
+    "value": {
+      "description": "Optional user data to represent",
+      "type": "string",
+      "enum": ["BARCODE", "USERNAME", "FIRST_NAME", "MIDDLE_NAME", "LAST_NAME", "PATRON_GROUP_ID", "EXTERNAL_SYSTEM_ID"]
+    },
+    "placeholder": {
+      "description": "Placeholder text to display when no value is present",
+      "type": "string"
+    },
+    "lengthControl": {
+      "description": "Control length of token",
+      "$ref": "bursarExportTokenLengthControl.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type", "value", "placeholder"]
+}

--- a/schemas/bursar-export/transfer/bursarExportTransferCriteria.json
+++ b/schemas/bursar-export/transfer/bursarExportTransferCriteria.json
@@ -1,0 +1,41 @@
+{
+  "description": "Transfer criteria",
+  "type": "object",
+  "properties": {
+    "conditions": {
+      "description": "Conditions to apply to the transfer of fees/fines",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "condition": {
+            "description": "Condition to apply tp this item",
+            "$ref": "../filter/bursarExportFilter.json"
+          },
+          "account": {
+            "description": "Account to transfer fees/fines that meet this condition to",
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["condition", "account"]
+      }
+    },
+    "else": {
+      "type": "object",
+      "description": "If none of the specified conditions is met",
+      "properties": {
+        "account": {
+          "description": "Account to transfer fees/fines that do not meet any specified conditions to",
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["account"]
+    }
+  },
+  "additionalProperties": false,
+  "required": ["conditions", "else"]
+}

--- a/schemas/feesfines/owner.json
+++ b/schemas/feesfines/owner.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "CRUD functions for Fee/Fine Owners",
+  "Owner": {
+    "type": "object",
+    "title": "CRUD Owner schema",
+    "properties": {
+      "owner": {
+        "description": "Service desk (known as a fee/fine owner) is library-defined and is associated with specific fees/fines",
+        "type": "string"
+      },
+      "desc": {
+        "description": "Owner description",
+        "type": "string"
+      },
+      "servicePointOwner": {
+        "description": "Service points associated to a Owner",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "description": "ID of the service-point",
+              "type": "string"
+            },
+            "label": {
+              "description": "Service-point name label",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value"
+          ]
+        }
+      },
+      "defaultChargeNoticeId": {
+        "description": "ID of the fee/fine charge template",
+        "type": "string"
+      },
+      "defaultActionNoticeId": {
+        "description": "ID of the fee/fine action template",
+        "type": "string"
+      },
+      "metadata": {
+        "description": "Metadata about creation to owner, provided by the server",
+        "type": "object",
+        "$ref": "../common/metadata.json#/Metadata"
+      },
+      "id": {
+        "description": "Owner id, UUID",
+        "type": "string"
+      }
+    },
+    "additionalProperties": false
+  }
+}
+
+
+

--- a/schemas/feesfines/ownerDataCollection.json
+++ b/schemas/feesfines/ownerDataCollection.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Collection of owners",
+  "OwnerDataCollection": {
+    "type": "object",
+    "properties": {
+      "owners": {
+        "description": "List of owner items",
+        "type": "array",
+        "id": "ownersData",
+        "items": {
+          "type": "object",
+          "$ref": "owner.json#/Owner"
+        }
+      },
+      "totalRecords": {
+        "type": "integer"
+      }
+    },
+    "required": [
+      "owners",
+      "totalRecords"
+    ]
+  }
+}


### PR DESCRIPTION
[UXPROD-3903](https://issues.folio.org/browse/UXPROD-3903): This PR will merge team @folio-org/bama's new schemas in order to support the new bursar export configuration feature. This PR must be merged as the same time as or before the changes in `mod-data-export-spring`, `mod-data-export-worker`, and `ui-plugin-bursar-export`.

