### PR TITLE
MODEXPS-254 - sync action_type.json with original

### DIFF
--- a/schemas/circulationlog/action_type.json
+++ b/schemas/circulationlog/action_type.json
@@ -41,6 +41,8 @@
       "Send",
       "Send error",
       "Staff information only added",
+      "Patron info added",
+      "Staff info added",
       "Transferred fully",
       "Transferred partially",
       "Waived fully",


### PR DESCRIPTION
## Purpose
folio-export-common's  schema action_type.json must at any time be identical to the original schema in mod-audit or the circulation log export will fail if some of the values are missing in action_type.json but present in the circulation log. 

## Approach
Copy missing enumeration values from mod-audit/action_type.json to folio-export-common/action_type.json

The change has been tested in an installation with data-export-spring and an active circulation log with the missing values in - see test plan at https://folio-org.atlassian.net/browse/MODEXPS-254?focusedCommentId=203700

### TODOS and Open Questions
Once merged, mod-data-export-spring and mod-data-export-worker should be updated to point to the new sub-module commit of folio-export-common.