### PR TITLE
feat[auth-export-report] Enhance "MARC authority headings update" Report with Record Type Column Based on Consortium Environment.

### DIFF
--- a/schemas/authority-control/authorityDataStatDto.json
+++ b/schemas/authority-control/authorityDataStatDto.json
@@ -56,6 +56,10 @@
         "type": "string",
         "description": "New source file ID"
       },
+      "shared": {
+        "type": "boolean",
+        "description": "True if authority is shared between multiple tenants"
+      },
       "lbTotal": {
         "type": "integer",
         "description": "Amount of linked bib fields"


### PR DESCRIPTION
## Purpose
 [MODEXPW-576](https://folio-org.atlassian.net/browse/MODEXPW-576) In a consortium environment, MARC authority records can be either shared across tenants within the consortium or local to each tenant. Report generation in mod-data-export-worker currently does not distinguish between shared and local records or reflect this distinction in export output. To improve clarity for users, report such as ""MARC authority headings update" should include appropriate column ("Authority record type") with the values "Shared" or "Local", depending on the record type. For non-consortium environments, these columns should not appear in the reports.

## Approach
Include a new `shared` field in the AuthorityDataStatDto schema.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
