### PR TITLE
MODEXPW-625 - Schema changes for sending exports via email

### DIFF
--- a/schemas/acquisitions/ediEmail.json
+++ b/schemas/acquisitions/ediEmail.json
@@ -15,6 +15,11 @@
       "isPrimaryTransmissionMethod": {
         "description": "Primary transmission method",
         "type": "boolean"
+      },
+      "emailTemplate": {
+        "description": "UUID reference to the email template",
+        "type": "string",
+        "format": "uuid"
       }
     }
   }

--- a/schemas/acquisitions/vendorEdiOrdersExportConfig.json
+++ b/schemas/acquisitions/vendorEdiOrdersExportConfig.json
@@ -26,6 +26,9 @@
         "description": "EDI config for this vendor",
         "$ref": "ediConfig.json#/EdiConfig"
       },
+      "ediEmail": {
+        "$ref": "ediEmail.json#/EdiEmail"
+      },
       "ediFtp": {
         "$ref": "ediFtp.json#/EdiFtp"
       },

--- a/schemas/acquisitions/vendorEdiOrdersExportConfig.json
+++ b/schemas/acquisitions/vendorEdiOrdersExportConfig.json
@@ -62,8 +62,7 @@
         "type": "string",
         "enum": [
           "CSV",
-          "EDI",
-          "EML"
+          "EDI"
         ]
       },
       "claimPieceIds": {

--- a/schemas/acquisitions/vendorEdiOrdersExportConfig.json
+++ b/schemas/acquisitions/vendorEdiOrdersExportConfig.json
@@ -62,7 +62,8 @@
         "type": "string",
         "enum": [
           "CSV",
-          "EDI"
+          "EDI",
+          "EML"
         ]
       },
       "claimPieceIds": {

--- a/schemas/acquisitions/vendorEdiOrdersExportConfig.json
+++ b/schemas/acquisitions/vendorEdiOrdersExportConfig.json
@@ -50,7 +50,8 @@
         "type": "string",
         "enum": [
           "FTP",
-          "File download"
+          "File download",
+          "Email"
         ]
       },
       "fileFormat": {

--- a/schemas/email/attachment.json
+++ b/schemas/email/attachment.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Message attachment",
+  "additionalProperties": false,
+  "properties": {
+    "contentType": {
+      "type": "string",
+      "description": "Content type"
+    },
+    "name": {
+      "type": "string",
+      "description": "Name"
+    },
+    "description": {
+      "type": "string",
+      "description": "Description"
+    },
+    "data": {
+      "type": "string",
+      "description": "Attachment data"
+    },
+    "disposition": {
+      "type": "string",
+      "description": "Disposition"
+    },
+    "contentId": {
+      "type": "string",
+      "description": "Content id"
+    }
+  }
+}

--- a/schemas/email/email_entity.json
+++ b/schemas/email/email_entity.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "The mail message that can be sent via email",
+  "title": "Email Entity Schema",
+  "type": "object",
+  "properties": {
+    "notificationId": {
+      "description":"notification identifier",
+      "type": "string"
+    },
+    "from": {
+      "description":"sender's address",
+      "type": "string"
+    },
+    "to": {
+      "description":"address of the recipient",
+      "type": "string"
+    },
+    "header": {
+      "description":"subject of email",
+      "type": "string"
+    },
+    "outputFormat": {
+      "description":"format type: `text/html` or `text/plain`",
+      "type": "string"
+    },
+    "body": {
+      "description":"text of email",
+      "type": "string"
+    },
+    "attachments": {
+      "description":"attachment list",
+      "id": "attachmentData",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "attachment.json"
+      }
+    }
+  },
+  "required": [
+    "notificationId",
+    "to",
+    "header",
+    "body"
+  ]
+}


### PR DESCRIPTION
[MODEXPW-625
](https://folio-org.atlassian.net/browse/MODEXPW-625)  - Schema changes for sending exports via email

## Purpose
Apply necessary changes to the schema, including updates to existing schemes and the addition of email and attachment schemes. 

This issue is part of the broader email delivery feature for EDIFACT Orders and Claims export jobs in mod-data-export-worker. When transmissionMethod == "Email", the export pipeline renders the EDIFACT file using the referenced template and delivers it via mod-email.

## Approach

- Add reference to existing ediEmail scheme
- Extend ediEmail scheme with Email template UUID
- Added "Email" to the transmissionMethod enum
- Adding schemes for email entity and attachment