### PR TITLE
[MODEXPW-624] Support dry runs for bursar exports

### DIFF
--- a/schemas/bursar-export/bursarExportJob.json
+++ b/schemas/bursar-export/bursarExportJob.json
@@ -38,6 +38,10 @@
     "transferInfo": {
       "description": "Transfer information for the export",
       "$ref": "transfer/bursarExportTransferCriteria.json"
+    },
+    "dryRun": {
+      "description": "Whether this export is a dry run (i.e. no actual transfer will be performed)",
+      "type": "boolean"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
 # [Jira MODEXPW-624](https://folio-org.atlassian.net/browse/MODEXPW-624)

## Purpose
Users would like to run bursar exports without the underlying accounts being transferred. This allows easier testing and verification of the export configurations before any data are actually changed.

## Approach
Adds a `dryRun` flag to the configuration schema.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues